### PR TITLE
Allow propTypes to pass through decoration

### DIFF
--- a/src/__specs__/styleable.spec.js
+++ b/src/__specs__/styleable.spec.js
@@ -24,12 +24,39 @@ function mkFixture(css) {
   return Subject
 }
 
+function mkFixtureWithReqPropTypes() {
+  @styleable(css)
+  class Subject extends React.Component {
+    static propTypes = {
+      aReqProp: React.PropTypes.string.isRequired
+    };
+    render() {
+      return (
+        <div className={this.props.css.content} ref="content">Req content {this.props.aReqProp}</div>
+      )
+    }
+  }
+
+  return Subject
+}
+
 function mkFunctionFixture(css) {
   function subject(props) {
     return <div className={props.css.content}>Content {props.aDefault}</div>
   }
   subject.defaultProps = {
     aDefault: 'still here'
+  }
+
+  return styleable(css)(subject)
+}
+
+function mkFunctionFixtureWithReqPropTypes() {
+  function subject(props) {
+    return <div className={props.css.content}>Req content {props.aReqProp}</div>
+  }
+  subject.propTypes = {
+    aReqProp: React.PropTypes.string.isRequired
   }
 
   return styleable(css)(subject)
@@ -104,8 +131,14 @@ describe('styleable', () => {
 
   it('lets defaultProps pass through', () => {
     const Subject = mkFixture()
+    Subject.defaultProps.aDefault.should.exist
     const component = TestUtils.renderIntoDocument(<Subject />)
     component.props.aDefault.should.eql('still here')
+  })
+
+  it('lets propTypes pass through', () => {
+    const Subject = mkFixtureWithReqPropTypes()
+    Subject.propTypes.aReqProp.should.exist
   })
 
   describe('with stateless functions', () => {
@@ -128,10 +161,20 @@ describe('styleable', () => {
 
     it('lets defaultProps pass through', () => {
       const Subject = mkFunctionFixture()
+      Subject.defaultProps.aDefault.should.exist
       const component = TestUtils.renderIntoDocument(<div><Subject /></div>)
       ReactDOM.findDOMNode(component).children[0].textContent.should.eql('Content still here')
     })
 
+    it('lets propTypes pass through', () => {
+      const Subject = mkFunctionFixtureWithReqPropTypes()
+      /*
+        Not sure how to really test the real problem where warnings aren't
+        happening when a child component has been styleable'd. This at least
+        tests the fix for the real problem.
+      */
+      Subject.propTypes.aReqProp.should.exist
+    })
   })
 
 })

--- a/src/styleable.js
+++ b/src/styleable.js
@@ -38,10 +38,9 @@ export default function styleable(stylesheet) {
     throw new Error('stylesheet must be an object (eg, export object from a css module)')
 
   return function decorateSource(DecoratedComponent) {
-    if (!isClass(DecoratedComponent))
-      return function styledFn(props) {
+    if (!isClass(DecoratedComponent)) {
+      const styledFn = function (props) {
         return DecoratedComponent({
-          ...DecoratedComponent.defaultProps,
           ...props,
           css: {
             ...stylesheet,
@@ -49,6 +48,10 @@ export default function styleable(stylesheet) {
           }
         });
       }
+      styledFn.defaultProps = DecoratedComponent.defaultProps
+      styledFn.propTypes = DecoratedComponent.propTypes
+      return styledFn
+    }
     else
       return class Styleable extends React.Component {
         static displayName = `Styleable(${getDisplayName(DecoratedComponent)})`;
@@ -57,6 +60,7 @@ export default function styleable(stylesheet) {
           css: {}
         };
         static propTypes = {
+          ...DecoratedComponent.propTypes,
           css: React.PropTypes.object
         };
         getCss() {


### PR DESCRIPTION
Styleable wasn't passing propTypes on after decoration. This results in
components losing propType isRequired flags when being rendered in
parent components.

Fix for #4