### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^15.0.0"
   },
   "dependencies": {
     "invariant": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "cz-conventional-changelog": "^1.1.5",
     "jsdom": "^7.2.2",
     "mocha": "^2.3.3",
-    "react-addons-test-utils": "^0.14.0",
-    "react-dom": "^0.14.0",
+    "react-addons-test-utils": "^15.0.0",
+    "react-dom": "^15.0.0",
     "rf-release": "^0.4.0",
     "semantic-release": "^4.3.5",
     "should": "^7.0.1"


### PR DESCRIPTION
Currently if you try to install react-styleable you get the following error:

The package react@15.0.1 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-dom@15.0.1 wants react@^15.0.1
npm ERR! peerinvalid Peer react-styleable@2.2.3 wants react@^0.14.0

I couldn't see any issue with just changing the version number of the react peerDependency when looking at the release notes: https://github.com/facebook/react/releases

Maybe you guys will spot something...