### PR TITLE
updating to react v15.5.4 and fixing propTypes warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "cz-conventional-changelog": "^1.1.5",
     "jsdom": "^7.2.2",
     "mocha": "^2.3.3",
-    "react": "^15.0.0",
-    "react-addons-test-utils": "^15.0.0",
-    "react-dom": "^15.0.0",
+    "react": "^15.5.4",
+    "prop-types": "15.5.8",
+    "react-dom": "^15.5.4",
     "rf-release": "^0.4.0",
     "semantic-release": "^4.3.5",
     "should": "^7.0.1"

--- a/src/__specs__/styleable.spec.js
+++ b/src/__specs__/styleable.spec.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import TestUtils from 'react-addons-test-utils'
+import TestUtils from 'react-dom/test-utils'
+import PropTypes from 'prop-types'
 
 import styleable from '../styleable'
 
@@ -28,7 +29,7 @@ function mkFixtureWithReqPropTypes() {
   @styleable(css)
   class Subject extends React.Component {
     static propTypes = {
-      aReqProp: React.PropTypes.string.isRequired
+      aReqProp: PropTypes.string.isRequired
     };
     render() {
       return (
@@ -56,7 +57,7 @@ function mkFunctionFixtureWithReqPropTypes() {
     return <div className={props.css.content}>Req content {props.aReqProp}</div>
   }
   subject.propTypes = {
-    aReqProp: React.PropTypes.string.isRequired
+    aReqProp: PropTypes.string.isRequired
   }
 
   return styleable(css)(subject)

--- a/src/styleable.js
+++ b/src/styleable.js
@@ -1,6 +1,7 @@
 import getDisplayName from './utils/get-display-name'
 import invariant from 'invariant'
 import React from 'react'
+import PropTypes from 'prop-types'
 
 function getSelectorsNotInStylesheet(cssProps, stylesheet) {
   const propKeys = Object.keys(cssProps)
@@ -61,7 +62,7 @@ export default function styleable(stylesheet) {
         };
         static propTypes = {
           ...DecoratedComponent.propTypes,
-          css: React.PropTypes.object
+          css: PropTypes.object
         };
         getCss() {
           invariant(


### PR DESCRIPTION
Hi there.
We've updated the react version in our code and react-styleable is popping some warnings due to the propTypes change.

This PR is updating the react version, installing `prop-types` from it's standalone package, and using `TestUtils` from `react-dom/test-utils` instead of `react-addons-test-utils`