### PR TITLE
update react peerDependency to support react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": ">=0.15.0 < 17.0.0"
   },
   "dependencies": {
     "invariant": "^2.1.0",


### PR DESCRIPTION
In reference to https://github.com/pluralsight/react-styleable/issues/13

Removes warning `react-styleable@2.2.5 requires a peer of react@^0.14.0 || ^15.0.0 but none is installed. You must install peer dependencies yourself.`